### PR TITLE
Add support for preview-fn

### DIFF
--- a/src/fzf/bbnc.clj
+++ b/src/fzf/bbnc.clj
@@ -1,0 +1,23 @@
+(ns fzf.bbnc
+  (:import (java.io BufferedInputStream BufferedOutputStream BufferedReader InputStreamReader PrintWriter)
+           (java.net Socket)
+           (java.nio.charset StandardCharsets)))
+
+(defn -main [& args]
+  (when (= 2 (count args))
+    (let [[port selected] args]
+      (with-open [sock (Socket. "127.0.0.1" (Integer/valueOf ^String port 10))]
+        (with-open [in (BufferedReader. (InputStreamReader. (BufferedInputStream. (.getInputStream sock)) StandardCharsets/UTF_8))
+                    out (PrintWriter. (BufferedOutputStream. (.getOutputStream sock)) true StandardCharsets/UTF_8)]
+          (.println out (str selected))
+          (.flush out)
+          (loop []
+            (when-let [lin (try (.readLine in)
+                                (catch Throwable _
+                                  nil))]
+              (println lin)
+              (flush)
+              (recur))))))))
+
+#_(when (= *file* (System/getProperty "babashka.file")))
+(apply -main *command-line-args*)

--- a/src/fzf/core.clj
+++ b/src/fzf/core.clj
@@ -25,18 +25,19 @@
 (s/def :fzf/exact boolean?)
 
 (s/def :fzf/opts
-  (s/keys
-   :opt-un [:fzf/in
-            :fzf/dir
-            :fzf/multi
-            :fzf/preview
-            :fzf/preview-fn
-            :fzf/reverse
-            :fzf/header
-            :fzf/height
-            :fzf/tac
-            :fzf/case-insensitive
-            :fzf/exact]))
+  (s/and  (s/keys
+           :opt-un [:fzf/in
+                    :fzf/dir
+                    :fzf/multi
+                    :fzf/preview
+                    :fzf/preview-fn
+                    :fzf/reverse
+                    :fzf/header
+                    :fzf/height
+                    :fzf/tac
+                    :fzf/case-insensitive
+                    :fzf/exact])
+          #(not (and (:preview %) (:preview-fn %)))))
 
 (s/def :fzf/args
   (s/coll-of string?))
@@ -87,10 +88,7 @@
    (if (map? opts-or-args)
      (fzf opts-or-args [])
      (fzf {} opts-or-args)))
-  ([{:keys [preview preview-fn] :as opts} args]
-   {:pre [(s/and (s/valid? :fzf/opts opts)
-                 (s/valid? :fzf/args args))]}
-   (when (and (some? preview) (some? preview-fn))
-     (throw (ex-info "Both :preview and :preview-fn given. Only one must be used."
-                     (select-keys opts [:preview :preview-fn]))))
+  ([opts args]
+   {:pre [(and (s/valid? :fzf/opts opts)
+               (s/valid? :fzf/args args))]}
    (i/fzf opts args)))

--- a/src/fzf/core.clj
+++ b/src/fzf/core.clj
@@ -50,6 +50,8 @@
    - preview: String, preview-command for the currently selected item
    - preview-fn: Function, preview function that will be called on the currently selected item.
                  Its return value will be displayed in the preview window.
+                 :preview-fn cannot be used in combination with :preview, i.e.
+                 only one of them can be used for a single invocation of fzf.
    - reverse: Bool, reverse the order of the fzf input dialogue
    - header: Map with sticky-header options for the fzf input dialogue
      - header-str: String, header-text
@@ -85,7 +87,10 @@
    (if (map? opts-or-args)
      (fzf opts-or-args [])
      (fzf {} opts-or-args)))
-  ([opts args]
+  ([{:keys [preview preview-fn] :as opts} args]
    {:pre [(s/and (s/valid? :fzf/opts opts)
                  (s/valid? :fzf/args args))]}
+   (when (and (some? preview) (some? preview-fn))
+     (throw (ex-info "Both :preview and :preview-fn given. Only one must be used."
+                     (select-keys opts [:preview :preview-fn]))))
    (i/fzf opts args)))

--- a/src/fzf/core.clj
+++ b/src/fzf/core.clj
@@ -16,6 +16,7 @@
 (s/def :fzf/dir fs/directory?)
 (s/def :fzf/multi boolean?)
 (s/def :fzf/preview string?)
+(s/def :fzf/preview-fn fn?)
 
 (s/def :fzf/reverse boolean?)
 (s/def :fzf/height (s/and string? #(re-matches #"^~?\d+%?$" %)))
@@ -29,6 +30,7 @@
             :fzf/dir
             :fzf/multi
             :fzf/preview
+            :fzf/preview-fn
             :fzf/reverse
             :fzf/header
             :fzf/height
@@ -41,11 +43,13 @@
 
 (defn fzf
   "Public interface to fzf.
-   
+
    `opts`: Options map (all keys are optional)
    - dir: String indicating the startup-dir of the fzf-command
    - multi: Bool, toggles multi-select in fzf. If true, fzf returns a vector instead of string
    - preview: String, preview-command for the currently selected item
+   - preview-fn: Function, preview function that will be called on the currently selected item.
+                 Its return value will be displayed in the preview window.
    - reverse: Bool, reverse the order of the fzf input dialogue
    - header: Map with sticky-header options for the fzf input dialogue
      - header-str: String, header-text
@@ -57,7 +61,7 @@
    - exact: Bool, toggle exact search (default: fuzzy)
 
    `args`: Input arguments to fzf (optional, list of strings)
-   
+
    Examples:
 
    (fzf) ;; => \"myfile.txt\"
@@ -69,8 +73,8 @@
 
    (fzf {:multi true
          :reverse true}
-       [\"one \" \"two \" \"three \"]) ;; => [\"one\" \"two\"] 
-     
+       [\"one \" \"two \" \"three \"]) ;; => [\"one\" \"two\"]
+
 
    Returns:
    - on success with :multi = false (default): the selected item as string

--- a/src/fzf/impl.clj
+++ b/src/fzf/impl.clj
@@ -2,7 +2,10 @@
   "Implementation of fzf-wrapper"
   (:require [babashka.fs :as fs]
             [babashka.process :as p]
-            [clojure.string :as str]))
+            [clojure.string :as str])
+  (:import (java.io BufferedInputStream BufferedOutputStream BufferedReader Closeable InputStreamReader PrintWriter)
+           (java.net InetSocketAddress ServerSocket Socket)
+           (java.nio.charset StandardCharsets)))
 
 (defn parse-opts
   "Parse fzf and process options"
@@ -23,16 +26,74 @@
      :opts (cond-> {:in :inherit
                     :out :string
                     :err :inherit}
-             (not-empty args) (assoc :in (str/join "\n" args))
-             dir (assoc :dir (-> dir fs/expand-home str)))}))
+                   (not-empty args) (assoc :in (str/join "\n" args))
+                   dir (assoc :dir (-> dir fs/expand-home str)))}))
+
+(defn start-preview-fn-server
+  "Start the preview function server.
+
+  The fzf preview command, a bb script, will connect to this server,
+  send the selected item and print the response.
+
+  This server will produce the response by
+  invoking `preview-fn` with the selected item as the only argument."
+  ^Closeable [port-promise preview-fn]
+  (let [ss (doto
+             (ServerSocket.)
+             (.bind (InetSocketAddress. "127.0.0.1" 0)))]
+    (future
+      (deliver port-promise (.getLocalPort ss))
+      (loop []
+        (when-let [^Socket sock (try
+                                  (.accept ss)
+                                  (catch Throwable _
+                                    nil))]
+          (try
+            (with-open [in (BufferedReader. (InputStreamReader. (BufferedInputStream. (.getInputStream sock)) StandardCharsets/UTF_8))
+                        out (PrintWriter. (BufferedOutputStream. (.getOutputStream sock)) true StandardCharsets/UTF_8)]
+              (let [input (.readLine in)
+                    response (str (preview-fn input))]
+                (.println out ^String response)
+                (.flush out)))
+            (catch Throwable _
+              nil)
+            (finally
+              (try
+                (.close sock)
+                (catch Throwable _
+                  nil))))
+          (recur))))
+    ss))
+
+(def script
+  "A verbatim copy of the namespace bbnc.
+  This script does the following:
+  1. connect to the preview server,
+  2. send the argument and
+  3. print the response."
+  "(ns fzf.bbnc\n  (:import (java.io BufferedInputStream BufferedOutputStream BufferedReader InputStreamReader PrintWriter)\n           (java.net Socket)\n           (java.nio.charset StandardCharsets)))\n\n(defn -main [& args]\n  (when (= 2 (count args))\n    (let [[port selected] args]\n      (with-open [sock (Socket. \"127.0.0.1\" (Integer/valueOf ^String port 10))]\n        (with-open [in (BufferedReader. (InputStreamReader. (BufferedInputStream. (.getInputStream sock)) StandardCharsets/UTF_8))\n                    out (PrintWriter. (BufferedOutputStream. (.getOutputStream sock)) true StandardCharsets/UTF_8)]\n          (.println out (str selected))\n          (.flush out)\n          (loop []\n            (when-let [lin (try (.readLine in)\n                                (catch Throwable _\n                                  nil))]\n              (println lin)\n              (flush)\n              (recur))))))))\n\n#_(when (= *file* (System/getProperty \"babashka.file\")))\n(apply -main *command-line-args*)\n")
 
 (defn fzf
   "Internal interface to fzf"
-  [opts args]
-  (let [multi (:multi opts)
-        {:keys [cmd opts]} (parse-opts opts args)
-        {:keys [out exit]} @(p/process cmd opts)]
-    (if (zero? exit)
-      (cond-> (str/trim out)
-        multi str/split-lines)
-      nil)))
+  [{:keys [preview-fn] :as opts} args]
+  (let [port-promise (promise)]
+    (with-open [^Closeable _server (if preview-fn
+                                     (start-preview-fn-server port-promise preview-fn)
+                                     (reify Closeable
+                                       (close [_] nil)))]
+      (let [multi (:multi opts)
+            opts (update opts
+                         :preview
+                         (fn [old-preview]
+                           (if preview-fn
+                             (str/join " " ["bb"
+                                            (str "-e '" script "'")
+                                            (str @port-promise)
+                                            "{}"])
+                             old-preview)))
+            {:keys [cmd opts]} (parse-opts opts args)
+            {:keys [out exit]} @(p/process cmd opts)]
+        (if (zero? exit)
+          (cond-> (str/trim out)
+                  multi str/split-lines)
+          nil)))))

--- a/src/fzf/impl.clj
+++ b/src/fzf/impl.clj
@@ -3,31 +3,48 @@
   (:require [babashka.fs :as fs]
             [babashka.process :as p]
             [clojure.string :as str])
-  (:import (java.io BufferedInputStream BufferedOutputStream BufferedReader Closeable InputStreamReader PrintWriter)
+  (:import (java.io BufferedInputStream BufferedOutputStream BufferedReader ByteArrayOutputStream Closeable InputStreamReader PrintWriter)
            (java.net InetSocketAddress ServerSocket Socket)
            (java.nio.charset StandardCharsets)))
 
+(def bbnc-script
+  "A verbatim copy of the namespace bbnc.
+  This script does the following:
+  1. connect to the preview server,
+  2. send the argument and
+  3. print the response."
+  "(ns fzf.bbnc\n  (:import (java.io BufferedInputStream BufferedOutputStream BufferedReader InputStreamReader PrintWriter)\n           (java.net Socket)\n           (java.nio.charset StandardCharsets)))\n\n(defn -main [& args]\n  (when (= 2 (count args))\n    (let [[port selected] args]\n      (with-open [sock (Socket. \"127.0.0.1\" (Integer/valueOf ^String port 10))]\n        (with-open [in (BufferedReader. (InputStreamReader. (BufferedInputStream. (.getInputStream sock)) StandardCharsets/UTF_8))\n                    out (PrintWriter. (BufferedOutputStream. (.getOutputStream sock)) true StandardCharsets/UTF_8)]\n          (.println out (str selected))\n          (.flush out)\n          (loop []\n            (when-let [lin (try (.readLine in)\n                                (catch Throwable _\n                                  nil))]\n              (println lin)\n              (flush)\n              (recur))))))))\n\n#_(when (= *file* (System/getProperty \"babashka.file\")))\n(apply -main *command-line-args*)\n")
+
+(defn bbnc-preview-command [port]
+  (str/join " " ["bb"
+                 (str "-e '" bbnc-script "'")
+                 (str port)
+                 "{}"]))
+
 (defn parse-opts
   "Parse fzf and process options"
-  [opts args]
-  (let [{:keys [dir multi preview tac case-insensitive exact reverse height]
-         {:keys [header-str header-lines header-first]} :header} opts]
-    {:cmd (cond-> ["fzf"]
-            multi (conj "--multi")
-            reverse (conj "--reverse")
-            tac (conj "--tac")
-            case-insensitive (conj "-i")
-            exact (conj "--exact")
-            preview (conj "--preview" preview)
-            header-str (conj "--header" header-str)
-            header-lines (conj "--header-lines" header-lines)
-            header-first (conj "--header-first")
-            height (conj "--height" height))
-     :opts (cond-> {:in :inherit
-                    :out :string
-                    :err :inherit}
-                   (not-empty args) (assoc :in (str/join "\n" args))
-                   dir (assoc :dir (-> dir fs/expand-home str)))}))
+  ([opts args]
+   (parse-opts opts args nil))
+  ([opts args server-port]
+   (let [{:keys [dir multi preview-fn preview tac case-insensitive exact reverse height]
+          {:keys [header-str header-lines header-first]} :header} opts]
+     {:cmd (cond-> ["fzf"]
+             multi (conj "--multi")
+             reverse (conj "--reverse")
+             tac (conj "--tac")
+             case-insensitive (conj "-i")
+             exact (conj "--exact")
+             preview-fn (conj "--preview" (bbnc-preview-command server-port))
+             preview (conj "--preview" preview)
+             header-str (conj "--header" header-str)
+             header-lines (conj "--header-lines" header-lines)
+             header-first (conj "--header-first")
+             height (conj "--height" height))
+      :opts (cond-> {:in :inherit
+                     :out :string
+                     :err :inherit}
+                    (not-empty args) (assoc :in (str/join "\n" args))
+                    dir (assoc :dir (-> dir fs/expand-home str)))})))
 
 (defn start-preview-fn-server
   "Start the preview function server.
@@ -65,33 +82,15 @@
           (recur))))
     ss))
 
-(def script
-  "A verbatim copy of the namespace bbnc.
-  This script does the following:
-  1. connect to the preview server,
-  2. send the argument and
-  3. print the response."
-  "(ns fzf.bbnc\n  (:import (java.io BufferedInputStream BufferedOutputStream BufferedReader InputStreamReader PrintWriter)\n           (java.net Socket)\n           (java.nio.charset StandardCharsets)))\n\n(defn -main [& args]\n  (when (= 2 (count args))\n    (let [[port selected] args]\n      (with-open [sock (Socket. \"127.0.0.1\" (Integer/valueOf ^String port 10))]\n        (with-open [in (BufferedReader. (InputStreamReader. (BufferedInputStream. (.getInputStream sock)) StandardCharsets/UTF_8))\n                    out (PrintWriter. (BufferedOutputStream. (.getOutputStream sock)) true StandardCharsets/UTF_8)]\n          (.println out (str selected))\n          (.flush out)\n          (loop []\n            (when-let [lin (try (.readLine in)\n                                (catch Throwable _\n                                  nil))]\n              (println lin)\n              (flush)\n              (recur))))))))\n\n#_(when (= *file* (System/getProperty \"babashka.file\")))\n(apply -main *command-line-args*)\n")
-
 (defn fzf
   "Internal interface to fzf"
   [{:keys [preview-fn] :as opts} args]
   (let [port-promise (promise)]
     (with-open [^Closeable _server (if preview-fn
                                      (start-preview-fn-server port-promise preview-fn)
-                                     (reify Closeable
-                                       (close [_] nil)))]
+                                     (ByteArrayOutputStream.))] ; any proper Closeable thing will do.
       (let [multi (:multi opts)
-            opts (update opts
-                         :preview
-                         (fn [old-preview]
-                           (if preview-fn
-                             (str/join " " ["bb"
-                                            (str "-e '" script "'")
-                                            (str @port-promise)
-                                            "{}"])
-                             old-preview)))
-            {:keys [cmd opts]} (parse-opts opts args)
+            {:keys [cmd opts]} (parse-opts opts args (when preview-fn @port-promise))
             {:keys [out exit]} @(p/process cmd opts)]
         (if (zero? exit)
           (cond-> (str/trim out)

--- a/test/fzf/core_test.clj
+++ b/test/fzf/core_test.clj
@@ -1,8 +1,8 @@
 (ns fzf.core-test
   (:require [clojure.test :as t]
             [fzf.core :as fzf])
-  (:import (clojure.lang ExceptionInfo)))
+  (:import (java.lang AssertionError)))
 
 (t/deftest fail-with-exception
   (t/testing "Using both :preview and :preview-fn causes exception"
-    (t/is (thrown? ExceptionInfo (fzf/fzf {:preview "foo" :preview-fn (fn [_] "bar")} ["a" "b" "c"])))))
+    (t/is (thrown? AssertionError (fzf/fzf {:preview "foo" :preview-fn (fn [_] "bar")} ["a" "b" "c"])))))

--- a/test/fzf/core_test.clj
+++ b/test/fzf/core_test.clj
@@ -1,0 +1,8 @@
+(ns fzf.core-test
+  (:require [clojure.test :as t]
+            [fzf.core :as fzf])
+  (:import (clojure.lang ExceptionInfo)))
+
+(t/deftest fail-with-exception
+  (t/testing "Using both :preview and :preview-fn causes exception"
+    (t/is (thrown? ExceptionInfo (fzf/fzf {:preview "foo" :preview-fn (fn [_] "bar")} ["a" "b" "c"])))))

--- a/test/fzf/impl_test.clj
+++ b/test/fzf/impl_test.clj
@@ -19,6 +19,11 @@
                                            :header-first true}
                                   :height "10%"}
                                  [])))))
+  (t/testing "adding :preview-fn produces command string with inline bb netcat script"
+    (t/is (= ["fzf" "--preview" (i/bbnc-preview-command 12345)]
+             (:cmd (i/parse-opts {:preview-fn (fn [_] "preview-fn")}
+                                 []
+                                 12345)))))
   (t/testing "providing input-arguments maps them to process stdin"
     (t/is (= {:in "one\ntwo\nthree", :out :string, :err :inherit}
              (:opts (i/parse-opts {} ["one" "two" "three"]))))


### PR DESCRIPTION
Hello

And thanks for a great project!

I added support for `:preview-fn`, which I thought could be a neat and handy feature.

It's implemented using a simple bb script that will be used as the preview command.
The bb script will connect to 127.0.0.1 : 'preview-fn-server-port', send the selected item and print out the response.

Example usage:
```clojure
(require '[fzf.core :refer [fzf]])

(println (fzf {:preview-fn (fn [nam] (str "Hello, " nam " :-)"))} ["one" "two" "three"]))
```

That will display as:
![image](https://github.com/joakimen/fzf.clj/assets/74075/0794aa17-eb89-45a0-8389-219ab0b1bd96)

It appears I've messed up some whitespace, sorry about that. If that is a problem, let me know and I can (probably!) fix it.

Kind regards.