### PR TITLE
Add support for --query and --select-1 fzf options

### DIFF
--- a/src/fzf/core.clj
+++ b/src/fzf/core.clj
@@ -38,7 +38,9 @@
                     :fzf/tac
                     :fzf/case-insensitive
                     :fzf/exact
-                    :fzf/throw])
+                    :fzf/throw
+                    :fzf/select-1
+                    :fzf/query])
           #(not (and (:preview %) (:preview-fn %)))))
 
 (s/def :fzf/args sequential?)
@@ -64,6 +66,8 @@
    - case-insensitive: Bool, toggle case-insensitive search (default: smart-case)
    - exact: Bool, toggle exact search (default: fuzzy)
    - throw: Bool, throw when no candidates were selected (default: return nil)
+   - select-1: Bool, automatically select if only one match
+   - query: String, start finder with the specified query
 
    `args`: Input arguments to fzf (optional, list of strings)
 

--- a/src/fzf/impl.clj
+++ b/src/fzf/impl.clj
@@ -26,7 +26,7 @@
   ([opts args]
    (parse-opts opts args nil))
   ([opts args server-port]
-   (let [{:keys [dir multi preview-fn preview tac case-insensitive exact reverse height]
+   (let [{:keys [dir multi preview-fn preview tac case-insensitive exact reverse height select-1 query]
           {:keys [header-str header-lines header-first]} :header} opts]
      {:cmd (cond-> ["fzf"]
              multi (conj "--multi")
@@ -39,7 +39,9 @@
              header-str (conj "--header" header-str)
              header-lines (conj "--header-lines" header-lines)
              header-first (conj "--header-first")
-             height (conj "--height" height))
+             height (conj "--height" height)
+             select-1 (conj "--select-1")
+             query (conj "--query" query))
       :opts (cond-> {:in :inherit
                      :out :string
                      :err :inherit}

--- a/test/fzf/impl_test.clj
+++ b/test/fzf/impl_test.clj
@@ -7,7 +7,7 @@
     (t/is (= {:cmd ["fzf"], :opts {:in :inherit, :out :string, :err :inherit}}
              (i/parse-opts {} []))))
   (t/testing "adding fzf flags produce correct command string"
-    (t/is (= ["fzf" "--multi" "--reverse" "--tac" "-i" "--exact" "--preview" "echo {}" "--header" "header-text" "--header-lines" 2 "--header-first" "--height" "10%"]
+    (t/is (= ["fzf" "--multi" "--reverse" "--tac" "-i" "--exact" "--preview" "echo {}" "--header" "header-text" "--header-lines" 2 "--header-first" "--height" "10%" "--select-1" "--query" "one"]
              (:cmd (i/parse-opts {:multi true
                                   :reverse true
                                   :tac true
@@ -18,7 +18,9 @@
                                            :header-lines 2
                                            :header-first true}
                                   :height "10%"
-                                  :throw true}
+                                  :throw true
+                                  :select-1 true
+                                  :query "one"}
                                  [])))))
   (t/testing "adding :preview-fn produces command string with inline bb netcat script"
     (t/is (= ["fzf" "--preview" (i/bbnc-preview-command 12345)]


### PR DESCRIPTION
Thanks for the great project.

I use the `--query` and `--select-1` options quite often when presenting options with fzf. This PR adds support for them.

Example, where "QUICK" is returned immediately:

```clojure
(->> ["quick" "brown" "fox"]
     (map s/upper-case)
     (fzf/fzf {:select-1 true
               :query "qui"}))
```

Let me know what you think. Thanks again.